### PR TITLE
Fix Incorrectly Inverted Port Order in `booth_multiplication`

### DIFF
--- a/Booth Multiplication/booth_multiplication.v
+++ b/Booth Multiplication/booth_multiplication.v
@@ -17,19 +17,19 @@ endmodule
 module nand2 (input wire i0, i1, output wire o);
    wire t;
    and2 and2_0 (i0, i1, t);
-   invert invert_0 (t, o);
+   invert invert_0 (o, t);
 endmodule
 
 module nor2 (input wire i0, i1, output wire o);
    wire t;
    or2 or2_0 (i0, i1, t);
-   invert invert_0 (t, o);
+   invert invert_0 (o, t);
 endmodule
 
 module xnor2 (input wire i0, i1, output wire o);
    wire t;
    xor2 xor2_0 (i0, i1, t);
-   invert invert_0 (t, o);
+   invert invert_0 (o, t);
 endmodule
 
 module and3 (input wire i0, i1, i2, output wire o);


### PR DESCRIPTION
### Description

This PR fixes incorrect port ordering in three module instantiations:

1. In `nand2` module (line 20): `invert invert_0(t, o)` $\to$ `invert invert_0(o, t)`
2. In `nor2` module (line 26): `invert invert_0(t, o)` $\to$ `invert invert_0(o, t)`
3. In `xnor2` module (line 32): `invert invert_0(t, o)` $\to$ `invert invert_0(o, t)`
The `invert` module is defined with `output ib`, `input b`, but these instances had the port connections reversed, which would cause incorrect behavior.

### ​​Changes​

Line 20, 26, 32 of `booth_multiplication.v`.