### PR TITLE
Fix FIFO buffer counter overflow by expanding counter bit width

### DIFF
--- a/FIFO/fifo.v
+++ b/FIFO/fifo.v
@@ -36,11 +36,11 @@ input   [31:0]    dataIn;
 
 output reg [31:0] dataOut; // internal registers 
 
-reg [2:0]  Count = 0; 
+reg [3:0]  Count = 0;
 
 reg [31:0] FIFO [0:7]; 
 
-reg [2:0]  readCounter = 0, 
+reg [3:0]  readCounter = 0,
 
            writeCounter = 0; 
 


### PR DESCRIPTION
### Description

This PR addresses an issue in the FIFO buffer implementation where the `FULL` condition was never being triggered due to counter overflow. The problem occurred because:
1. The 3-bit counters (`Count`, `readCounter`, `writeCounter`) could only count up to 7 (binary `111`)
2. The `FULL` condition check was looking for a value of `8`, which was impossible with 3 bits
3. The wrap-around conditions for counters reaching `8` would never execute

### Changes Made

- Expanded the bit width of `Count`, `readCounter`, and `writeCounter` from 3 bits to 4 bits
- This allows proper detection of the full state (`count = 8`) and correct counter wrap-around behavior

### Impact

This fix ensures proper FIFO operation, particularly when the buffer becomes full, preventing potential data corruption or loss.

### Changes

Line 39, 43 of `fifo.v`.