### PR TITLE
Fix CRC-32 serial counter overflow by expanding count bit width

### DIFF
--- a/CRC Coding/CRC_32_serial/CRC_32_serial.v
+++ b/CRC Coding/CRC_32_serial/CRC_32_serial.v
@@ -8,7 +8,7 @@ output crc_out; //
 reg crc_out; //
 reg [31:0] crc_reg; //
 reg [1:0] state; //
-reg [4:0] count; //
+reg [5:0] count; //
 parameter idle = 2'b00; //
 parameter compute = 2'b01; //
 parameter finish = 2'b10; //


### PR DESCRIPTION
### Description

This PR addresses an issue in the CRC-32 serial implementation where the finish state condition check for `count == 32` would never evaluate true due to counter overflow. The problem occurred because:
- The 5-bit counter (count) could only count up to 31 (binary `11111`)
- The finish state condition check was looking for a value of 32, which was impossible with 5 bits
- This prevented the state machine from properly transitioning back to `idle` after completing CRC calculation

### Changes Made

- Expanded the bit width of `count` from 5 bits to 6 bits
- This allows proper detection of the finish condition (`count == 32`) and correct state machine transitions

### Impact

This fix ensures proper CRC calculation completion and state machine operation, preventing potential stalling in the `finish` state.

### Changes

Line 11 of `CRC_32_serial.v`.
