### PR TITLE
Fix undefined signal reference in sequential multiplier (v → v1)

### DIFF
--- a/Sequential Multiplier/sequential_multiplication.v
+++ b/Sequential Multiplier/sequential_multiplication.v
@@ -14,7 +14,7 @@ counter u5 (t,l,clk);
 assign valid=l;
 adder u3 (y,po,c,s);
 s3 u4 (clk,v1,{c,s[7:1]},l,po);
- s4 e1 (clk,v,s[0],l,lo);
+ s4 e1 (clk,v1,s[0],l,lo);
 assign op={po,lo};
 assign v1= reset|load;
 assign t=reset|load;


### PR DESCRIPTION
### Description

This PR corrects a signal reference error in the sequential multiplier implementation that was causing simulation/synthesis issues due to an undefined signal.

### Bug Fix

Changed undefined signal `v` to correctly use defined signal `v1` in the `s4` module instantiation

### Files Changed

Line 17 of `sequential_multiplication.v`.
