### PR TITLE
Fix CRC_16_parallel FSM: Properly increment count in finish state to enable correct state transitions

### DIFF
--- a/CRC Coding/CRC_16_parallel/CRC_16_parallel.v
+++ b/CRC Coding/CRC_16_parallel/CRC_16_parallel.v
@@ -68,14 +68,17 @@ always@(posedge clk or negedge rst)//
  case(state) 
  idle:begin // 
  crc_reg[15:0] <= 16'b0000_0000_0000_0000; 
+ count <= 2'b00; // Reset count in idle
  end 
  compute:begin // 
  crc_reg[15:0]<= next_crc_reg[15:0]; 
  crc_out[7:0] <= crc_in[7:0]; 
+ count <= 2'b00; // Reset count in compute
  end 
  finish:begin //
  crc_reg[15:0] <= {crc_reg[7:0],8'b0000_0000}; 
  crc_out[7:0] <= crc_reg[15:8]; 
+ count <= count + 1'b1; // Increment count in finish
  end 
  endcase 
 endmodule 


### PR DESCRIPTION
### Problem

The original implementation of the `CRC_16_parallel` module had a bug where the `count` register was never incremented in the `finish` state. As a result, the FSM would never transition from `finish` back to `idle`, causing the module to get stuck.

### Solution

- The `count` register is now incremented on each clock cycle in the `finish` state.
- `count` is reset to zero in the `idle` and `compute` states.
- This ensures the FSM spends exactly two cycles in the `finish` state before returning to `idle`, as originally intended.

### Changes

Updated the `always` block to increment `count` in the `finish` state and reset it in other states.